### PR TITLE
build(local): Develop natively on the local host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+./.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.pyc
 .secret
 devel/src/*
+/buildout-cache
+
+# Exclude local development from Docker build context but include in VCS
+# https://www.rpatterson.net/blog/docker-gotchas/#build-context-and-image-stowaways
+/local-devel/*
+!/local-devel/.gitignore

--- a/local-devel/.env.cfg.in
+++ b/local-devel/.env.cfg.in
@@ -1,0 +1,1 @@
+../../eea.docker.plone/local-devel/.env.cfg.in

--- a/local-devel/.env.in
+++ b/local-devel/.env.in
@@ -1,0 +1,33 @@
+# Make non-default './docker-compose*.yml' files the default
+# https://pscheit.medium.com/docker-compose-advanced-configuration-541356d121de#9aa6
+COMPOSE_PATH_SEPARATOR=:
+# Use local development modifications to the base compose configuration
+# Keep paths relative, './docker-compose.local.yml' first
+# Depends on the 'eea.docker.plone' repo being checked out next to this repo
+# TODO: Better way to define this?  Can we add 'eea.docker.plone' as a '$ git submodule
+# ...' of this './local-devel/' directory without interfering with EEA build processes?
+COMPOSE_FILE=./docker-compose.local.yml:../../eea.docker.plone/docker-compose.yml
+
+# Default to the developer's personal development stack.
+# WARNING: May need to be customized if your local username differs from the prefix used
+# for that stack.
+RANCHER_STACK_PREFIX=${USER}
+
+# Symlink the buildout configuration files from '../../eea.docker.kgs/src/plone/*.cfg'
+# or override with those from '../src/plone/*.cfg'
+BUILDOUT_LAYER_DIRS=../../eea.docker.kgs/src/plone ../src/plone
+
+# Avoid port clashes with local development environments for other projects.
+# Choose a random port prefix in the IANA ephemeral port range, 49152-65535:
+# https://en.wikipedia.org/wiki/Ephemeral_port#Range
+# '$ shuf -i 49-65 -n 1'
+PORT_PREFIX=53
+
+# Override the newer versions in the support for local development from the more current
+# base image in 'eea.docker.plone'.
+# Versions from '.../plone.docker/4.3/4.3.19/debian/Dockerfile':
+PYTHON_EXECUTABLE=python2
+ZC_BUILDOUT_VERSION=2.13.1
+SETUPTOOLS_VERSION=40.8.0
+WHEEL_VERSION=0.33.1
+PLONE_VERSION=4.3.19

--- a/local-devel/.gitignore
+++ b/local-devel/.gitignore
@@ -1,0 +1,1 @@
+../../eea.docker.plone/local-devel/.gitignore

--- a/local-devel/Makefile
+++ b/local-devel/Makefile
@@ -1,0 +1,1 @@
+../../eea.docker.plone/local-devel/Makefile

--- a/local-devel/README.rst
+++ b/local-devel/README.rst
@@ -1,0 +1,1 @@
+../../eea.docker.plone/local-devel/README.rst

--- a/local-devel/base-zope.cfg
+++ b/local-devel/base-zope.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/base-zope.cfg

--- a/local-devel/base.cfg
+++ b/local-devel/base.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/base.cfg

--- a/local-devel/bin/.gitignore
+++ b/local-devel/bin/.gitignore
@@ -1,0 +1,1 @@
+../../../eea.docker.plone/local-devel/bin/.gitignore

--- a/local-devel/bin/mv-backup
+++ b/local-devel/bin/mv-backup
@@ -1,0 +1,1 @@
+../../../eea.docker.plone/local-devel/bin/mv-backup

--- a/local-devel/bin/rancher-rsh
+++ b/local-devel/bin/rancher-rsh
@@ -1,0 +1,1 @@
+../../../eea.docker.plone/local-devel/bin/rancher-rsh

--- a/local-devel/build-deps.txt
+++ b/local-devel/build-deps.txt
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/docker/build-deps.txt

--- a/local-devel/buildout-base.cfg
+++ b/local-devel/buildout-base.cfg
@@ -1,0 +1,1 @@
+./plone/buildout-base.cfg

--- a/local-devel/buildout.cfg
+++ b/local-devel/buildout.cfg
@@ -1,0 +1,1 @@
+../src/plone/buildout.cfg

--- a/local-devel/devel.cfg
+++ b/local-devel/devel.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/devel.cfg

--- a/local-devel/develop.cfg
+++ b/local-devel/develop.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/develop.cfg

--- a/local-devel/docker-compose.local.yml
+++ b/local-devel/docker-compose.local.yml
@@ -1,0 +1,1 @@
+../../eea.docker.plone/local-devel/docker-compose.local.yml

--- a/local-devel/eea-local.cfg
+++ b/local-devel/eea-local.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.plone/local-devel/local.cfg

--- a/local-devel/eea.cfg
+++ b/local-devel/eea.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/eea.cfg

--- a/local-devel/local.cfg
+++ b/local-devel/local.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/local-devel/local.cfg

--- a/local-devel/lxml_static.cfg
+++ b/local-devel/lxml_static.cfg
@@ -1,0 +1,1 @@
+./plone/lxml_static.cfg

--- a/local-devel/plone-versions.cfg
+++ b/local-devel/plone-versions.cfg
@@ -1,0 +1,1 @@
+./plone/versions.cfg

--- a/local-devel/postgresql.backup/.gitignore
+++ b/local-devel/postgresql.backup/.gitignore
@@ -1,0 +1,1 @@
+../../../eea.docker.plone/local-devel/postgresql.backup/.gitignore

--- a/local-devel/postgresql.backup/datafs.gz.update
+++ b/local-devel/postgresql.backup/datafs.gz.update
@@ -1,0 +1,3 @@
+# If newer than `./datafs.gz`,
+# then it will be updated from `rsync.$(RANCHER_STACK_PREFIX)-www-eea`:
+# `$ touch "./postgresql.backup/datafs.gz" && make "var/log/postgresql-restore.log"`

--- a/local-devel/run-deps.txt
+++ b/local-devel/run-deps.txt
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/docker/run-deps.txt

--- a/local-devel/sources-third-party.cfg
+++ b/local-devel/sources-third-party.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/sources-third-party.cfg

--- a/local-devel/sources.cfg
+++ b/local-devel/sources.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/sources.cfg

--- a/local-devel/versions.cfg
+++ b/local-devel/versions.cfg
@@ -1,0 +1,1 @@
+../../eea.docker.kgs/src/plone/versions.cfg

--- a/local-devel/www.cfg
+++ b/local-devel/www.cfg
@@ -1,0 +1,1 @@
+../src/plone/www.cfg

--- a/local-devel/zope-2-13-27-versions.cfg
+++ b/local-devel/zope-2-13-27-versions.cfg
@@ -1,0 +1,1 @@
+./plone/zope-2-13-27-versions.cfg

--- a/local-devel/zopetoolkit-1-0-8-zopeapp-versions.cfg
+++ b/local-devel/zopetoolkit-1-0-8-zopeapp-versions.cfg
@@ -1,0 +1,1 @@
+./plone/zopetoolkit-1-0-8-zopeapp-versions.cfg

--- a/local-devel/zopetoolkit-1-0-8-ztk-versions.cfg
+++ b/local-devel/zopetoolkit-1-0-8-ztk-versions.cfg
@@ -1,0 +1,1 @@
+./plone/zopetoolkit-1-0-8-ztk-versions.cfg


### PR DESCRIPTION
Symlinks the necessary files from `../eea.docker.plone/local-devel/*` to re-use the
support there for local development.

----

All of the changes here have been made to be isolated to the `./local-devel/`
subdirectory and should not affect anything or anyone else.  Since I'm now dependent on
these changes for my development, the tax for keeping this branch up to date will only
increase over time, so I'm hoping I can get this PR merged even if it's not widely used.
The only commits that touch anything outside of the `./local-devel/` subdirectory are
general improvements and should be pretty safe.

See [the corresponding "upstream" PR](https://github.com/eea/eea.docker.plone/pull/4)
for most context and details.  This is just an example of how the
`./local-devel/Makefile` from there can be re-used for other base images.